### PR TITLE
Inversion buffer commutation

### DIFF
--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1155,7 +1155,7 @@ void QUnit::CNOT(bitLenInt control, bitLenInt target)
 
         RevertBasis2Qb(control, INVERT_AND_PHASE, ONLY_TARGETS);
         RevertBasis2Qb(target, ONLY_PHASE, CONTROLS_AND_TARGETS);
-        RevertBasis2Qb(target, INVERT_AND_PHASE, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
+        RevertBasis2Qb(target, ONLY_INVERT, CONTROLS_AND_TARGETS, CTRL_AND_ANTI, {}, { control });
 
         shards[target].AddInversionAngles(&(shards[control]), ONE_CMPLX, ONE_CMPLX);
         return;


### PR DESCRIPTION
Yesterday, I intended for inversion buffers to be composable with identical gates (to cancel). However, I used the wrong number of arguments in `RevertBasis2Qb()`. I run very long cross entropy tests on these locally, so I'm waiting for this verification run to complete. If and when it does, I'll merge this.