### PR TITLE
Fix X/Y/Z single bit gates in new benchmarks

### DIFF
--- a/test/benchmarks.cpp
+++ b/test/benchmarks.cpp
@@ -683,7 +683,6 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
             qReg->SetReactiveSeparate(true);
 
             for (d = 0; d < benchmarkDepth; d++) {
-
                 for (i = 0; i < n; i++) {
                     gateRand = 2 * qReg->Rand();
                     // "Phase" transforms vs. "position" transforms
@@ -693,6 +692,7 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                         if (gateRand < ONE_R1) {
                             // Axis gross gate:
                             qReg->X(i);
+                            
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -702,7 +702,17 @@ TEST_CASE("test_stabilizer_t", "[supreme]")
                             }
                             // else - no SqrtX correction
                         } else if (gateRand < (2 * ONE_R1)) {
+                            // Axis gross gate:
                             qReg->Y(i);
+                            
+                            // Axis fine correction:
+                            gateRand = 3 * qReg->Rand();
+                            if (gateRand < ONE_R1) {
+                                qReg->SqrtY(i);
+                            } else if (gateRand < (2 * ONE_R1)) {
+                                qReg->ISqrtY(i);
+                            }
+                            // else - no SqrtX correction
                         } else if (gateRand < (3 * ONE_R1)) {
                             // Replace the body below with this for continuous Z axis root gates:
                             // gateRand = 2 * PI_R1 * qReg->Rand();
@@ -822,7 +832,6 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
             qReg->SetReactiveSeparate(true);
 
             for (d = 0; d < benchmarkDepth; d++) {
-
                 for (i = 0; i < n; i++) {
                     gateRand = 2 * qReg->Rand();
                     // "Phase" transforms vs. "position" transforms
@@ -832,6 +841,7 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         if (gateRand < ONE_R1) {
                             // Axis gross gate:
                             qReg->X(i);
+                            
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {
@@ -843,6 +853,7 @@ TEST_CASE("test_stabilizer_t_cc", "[supreme]")
                         } else if (gateRand < (2 * ONE_R1)) {
                             // Axis gross gate:
                             qReg->Y(i);
+                            
                             // Axis fine correction:
                             gateRand = 3 * qReg->Rand();
                             if (gateRand < ONE_R1) {


### PR DESCRIPTION
I forgot to update `test_stabilizer_t` gates in parallel to `test_stabilizer_t_cc`. The point is that X/Y/Z gates allow square root gates, and Z allows quarter roots. (I'm considering putting quarter roots on X and Y as well, equivalent to allowing a `T()` gate.)