### PR TITLE
Noise debug

### DIFF
--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -3047,19 +3047,6 @@ public:
      */
     virtual void DepolarizingChannelWeak1Qb(bitLenInt qubit, real1_f lambda);
 
-    /**
-     *  Simulate a local qubit depolarizing noise channel, under a "strong simulation condition." "Strong" condition
-     * supports measurement sampling and direct queries of state, but the expression of state is in terms of one
-     * retained ancillary qubit per applied noise channel. condition, sampling and exact state queries are not accurate,
-     * but sampling can be achieved via repeated full execution of a noisy circuit, for each hardware-realistic
-     * measurement sample.
-     *
-     * This method returns a newly-allocated qubit ancilla index which must be retained to maintain "strong" simulation.
-     * Note that "strong" ancilla can be measured at any time and discarded, but this makes the simulation condition
-     * "weak".
-     */
-    virtual bitLenInt DepolarizingChannelStrong1Qb(bitLenInt qubit, real1_f lambda);
-
     /** @} */
 };
 } // namespace Qrack

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -41,8 +41,9 @@ protected:
         if (n <= ZERO_R1_F) {
             return;
         }
-        std::cout << "noise" << std::endl;
+
         engine->DepolarizingChannelWeak1Qb(qb, n);
+
         if ((n + FP_NORM_EPSILON) >= ONE_R1_F) {
             logFidelity = -1 * std::numeric_limits<float>::infinity();
         } else {

--- a/include/qinterface_noisy.hpp
+++ b/include/qinterface_noisy.hpp
@@ -41,6 +41,7 @@ protected:
         if (n <= ZERO_R1_F) {
             return;
         }
+        std::cout << "noise" << std::endl;
         engine->DepolarizingChannelWeak1Qb(qb, n);
         if ((n + FP_NORM_EPSILON) >= ONE_R1_F) {
             logFidelity = -1 * std::numeric_limits<float>::infinity();

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -490,20 +490,16 @@ void QInterface::DepolarizingChannelWeak1Qb(bitLenInt qubit, real1_f lambda)
         return;
     }
 
-    // Original qubit, Z->X basis
-    H(qubit);
-
-    // Allocate an ancilla
-    const bitLenInt ancilla = Allocate(1U);
-    // Partially entangle with the ancilla
-    CRY(2 * asin(std::pow((real1_s)lambda, (real1_s)(1.0f / 4.0f))), qubit, ancilla);
-    // Partially collapse the original state
-    M(ancilla);
-    // The ancilla is fully separable, after measurement.
-    Dispose(ancilla, 1U);
-
-    // Uncompute
-    H(qubit);
+    const real1_f thirdLambda = lambda / 3;
+    if (Rand() < thirdLambda) {
+        engine->X(qb);
+    }
+    if (Rand() < thirdLambda) {
+        engine->Y(qb);
+    }
+    if (Rand() < thirdLambda) {
+        engine->Z(qb);
+    }
 }
 
 bitLenInt QInterface::DepolarizingChannelStrong1Qb(bitLenInt qubit, real1_f lambda)

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -492,13 +492,13 @@ void QInterface::DepolarizingChannelWeak1Qb(bitLenInt qubit, real1_f lambda)
 
     const real1_f thirdLambda = lambda / 3;
     if (Rand() < thirdLambda) {
-        X(qb);
+        X(qubit);
     }
     if (Rand() < thirdLambda) {
-        Y(qb);
+        Y(qubit);
     }
     if (Rand() < thirdLambda) {
-        Z(qb);
+        Z(qubit);
     }
 }
 

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -492,13 +492,13 @@ void QInterface::DepolarizingChannelWeak1Qb(bitLenInt qubit, real1_f lambda)
 
     const real1_f thirdLambda = lambda / 3;
     if (Rand() < thirdLambda) {
-        engine->X(qb);
+        X(qb);
     }
     if (Rand() < thirdLambda) {
-        engine->Y(qb);
+        Y(qb);
     }
     if (Rand() < thirdLambda) {
-        engine->Z(qb);
+        Z(qb);
     }
 }
 

--- a/src/qinterface/gates.cpp
+++ b/src/qinterface/gates.cpp
@@ -502,20 +502,4 @@ void QInterface::DepolarizingChannelWeak1Qb(bitLenInt qubit, real1_f lambda)
     }
 }
 
-bitLenInt QInterface::DepolarizingChannelStrong1Qb(bitLenInt qubit, real1_f lambda)
-{
-    // Original qubit, Z->X basis
-    H(qubit);
-
-    // Allocate an ancilla
-    const bitLenInt ancilla = Allocate(1U);
-    // Partially entangle with the ancilla
-    CRY(2 * asin(std::pow((real1_s)lambda, (real1_s)(1.0f / 4.0f))), qubit, ancilla);
-
-    // Uncompute
-    H(qubit);
-
-    return ancilla;
-}
-
 } // namespace Qrack


### PR DESCRIPTION
I had two forms of ("weak") depolarizing noise in Qrack. One was just canonical stochastic Pauli noise. The other was a "trick" that I thought was clever to notice was equivalent. Turns out, the "trick" was _not_ equivalent. At some point, in refactoring Qrack for other reasons, I replaced the stochastic Pauli noise channel with the incorrect "trick," throughout. Stochastic Pauli noise _does_ reproduce depolarizing noise statistics and works just fine, here.