### PR TITLE
Bitset stabilizer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Prepare Build Environment (Linux)
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ocl-icd-opencl-dev opencl-headers
+          sudo apt-get install -y build-essential cmake ocl-icd-opencl-dev opencl-headers libboost-dev
 
       - name: Build Qrack Linux x86-64
         run: |
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ocl-icd-opencl-dev opencl-headers
+          sudo apt-get install -y build-essential cmake ocl-icd-opencl-dev opencl-headers libboost-dev
 
       - name: Build Qrack Linux x86-64
         run: |
@@ -88,7 +88,7 @@ jobs:
 
       - name: Prepare Build Environment (MacOS)
         run: |
-          brew install cmake
+          brew install cmake boost
 
       - name: Build Qrack MacOS
         run: |
@@ -121,7 +121,7 @@ jobs:
 
       - name: Prepare Build Environment (MacOS)
         run: |
-          brew install cmake
+          brew install cmake boost
 
       - name: Build Qrack MacOS
         run: |
@@ -150,6 +150,14 @@ jobs:
       - name: Install vcpkg dependencies
         run: |
           vcpkg install opencl
+
+      - name: Install Boost
+        uses: MarkusJx/install-boost@v2.0.0
+        with:
+          boost_version: 1.82.0
+          toolset: msvc
+          platform_version: 2022
+          cache: true
 
       - name: Checkout Qrack
         uses: actions/checkout@v4

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -230,16 +230,23 @@ protected:
         SetTransposeState(false);
 #endif
 
+        r[i] = 0;
+
         BoolVector& xi = x[i];
         BoolVector& zi = z[i];
 #if BOOST_AVAILABLE
         xi.reset();
         zi.reset();
+
+        if (b < qubitCount) {
+            xi.set(b);
+        } else {
+            b -= qubitCount;
+            zi.set(b);
+        }
 #else
         std::fill(xi.begin(), xi.end(), false);
         std::fill(zi.begin(), zi.end(), false);
-#endif
-        r[i] = 0;
 
         if (b < qubitCount) {
             xi[b] = true;
@@ -247,10 +254,15 @@ protected:
             b -= qubitCount;
             zi[b] = true;
         }
+#endif
     }
     /// Left-multiply row i by row k - does not change the logical state
     void rowmult(const bitLenInt& i, const bitLenInt& k)
     {
+#if BOOST_AVAILABLE
+        SetTransposeState(false);
+#endif
+
         r[i] = clifford(i, k);
         BoolVector& xi = x[i];
         BoolVector& zi = z[i];

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -139,7 +139,8 @@ protected:
     }
 #endif
 
-    void ValidateQubitIndex(bitLenInt qubit) {
+    void ValidateQubitIndex(bitLenInt qubit)
+    {
         if (qubit >= qubitCount) {
             throw std::domain_error("QStabilizer gate qubit indices are out-of-bounds!");
         }

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -212,9 +212,6 @@ protected:
             return;
         }
 
-#if BOOST_AVAILABLE
-        SetTransposeState(false);
-#endif
         x[i] = x[k];
         z[i] = z[k];
         r[i] = r[k];
@@ -226,9 +223,6 @@ protected:
             return;
         }
 
-#if BOOST_AVAILABLE
-        SetTransposeState(false);
-#endif
         std::swap(x[k], x[i]);
         std::swap(z[k], z[i]);
         std::swap(r[k], r[i]);
@@ -236,10 +230,6 @@ protected:
     /// Sets row i equal to the bth observable (X_1,...X_n,Z_1,...,Z_n)
     void rowset(const bitLenInt& i, bitLenInt b)
     {
-#if BOOST_AVAILABLE
-        SetTransposeState(false);
-#endif
-
         r[i] = 0;
 
         BoolVector& xi = x[i];
@@ -269,10 +259,6 @@ protected:
     /// Left-multiply row i by row k - does not change the logical state
     void rowmult(const bitLenInt& i, const bitLenInt& k)
     {
-#if BOOST_AVAILABLE
-        SetTransposeState(false);
-#endif
-
         r[i] = clifford(i, k);
         BoolVector& xi = x[i];
         BoolVector& zi = z[i];
@@ -340,7 +326,7 @@ public:
      * (Return value = number of such generators = log_2 of number of nonzero basis states)
      * At the bottom, generators containing Z's only in quasi-upper-triangular form.
      */
-    bitLenInt gaussian();
+    bitLenInt gaussian(bool s=true);
 
     bitCapInt PermCount() { return pow2(gaussian()); }
 

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -56,14 +56,14 @@ protected:
     bool isTransposed;
 #endif
 
-    // Phase bits: 0 for +1, 1 for i, 2 for -1, 3 for -i.  Normally either 0 or 2.
-    std::vector<uint8_t> r;
     // Typedef for special type std::vector<bool> compatibility
 #if BOOST_AVAILABLE
     typedef boost::dynamic_bitset<> BoolVector;
 #else
     typedef std::vector<bool> BoolVector;
 #endif
+    // Phase bits: 0 for +1, 1 for i, 2 for -1, 3 for -i.  Normally either 0 or 2.
+    std::vector<uint8_t> r;
     // (2n+1)*n matrix for stabilizer/destabilizer x bits (there's one "scratch row" at the bottom)
     std::vector<BoolVector> x;
     // (2n+1)*n matrix for z bits

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -111,8 +111,8 @@ protected:
     // By Elara (OpenAI custom GPT)
     std::vector<boost::dynamic_bitset<>> FastTranspose(const std::vector<boost::dynamic_bitset<>>& matrix)
     {
-        size_t num_rows = matrix.size();
-        size_t num_cols = matrix[0].size();
+        const size_t num_rows = matrix.size();
+        const size_t num_cols = matrix[0].size();
 
         std::vector<BoolVector> transposed(num_cols, BoolVector(num_rows));
 
@@ -188,6 +188,7 @@ public:
         x.clear();
         z.clear();
         r.clear();
+        isTransposed = false;
         phaseOffset = ZERO_R1;
         qubitCount = 0U;
         maxQPower = ONE_BCI;
@@ -250,9 +251,6 @@ protected:
     /// Left-multiply row i by row k - does not change the logical state
     void rowmult(const bitLenInt& i, const bitLenInt& k)
     {
-#if BOOST_AVAILABLE
-        SetTransposeState(false);
-#endif
         r[i] = clifford(i, k);
         BoolVector& xi = x[i];
         BoolVector& zi = z[i];

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -99,7 +99,9 @@ protected:
         rawRandBools = orig->rawRandBools;
         rawRandBoolsRemaining = orig->rawRandBoolsRemaining;
         phaseOffset = orig->phaseOffset;
+#if BOOST_AVAILABLE
         isTransposed = orig->isTransposed;
+#endif
         maxStateMapCacheQubitCount = orig->maxStateMapCacheQubitCount;
         r = orig->r;
         x = orig->x;
@@ -187,7 +189,9 @@ public:
         x.clear();
         z.clear();
         r.clear();
+#if BOOST_AVAILABLE
         isTransposed = false;
+#endif
         phaseOffset = ZERO_R1;
         qubitCount = 0U;
         maxQPower = ONE_BCI;

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -112,8 +112,8 @@ protected:
     // By Elara (OpenAI custom GPT)
     std::vector<boost::dynamic_bitset<>> FastTranspose(const std::vector<boost::dynamic_bitset<>>& matrix)
     {
-        const size_t num_rows = matrix.size() - (isTransposed ? 0 : 1);
-        const size_t num_cols = matrix[0].size() + (isTransposed ? 1 : 0);
+        const size_t num_rows = matrix.size();
+        const size_t num_cols = matrix[0].size();
 
         std::vector<BoolVector> transposed(num_cols, BoolVector(num_rows));
 
@@ -133,9 +133,19 @@ protected:
             return;
         }
 
+        if (!isTransposed) {
+            x.pop_back();
+            z.pop_back();
+        }
+
         x = FastTranspose(x);
         z = FastTranspose(z);
         isTransposed = isTrans;
+
+        if (!isTransposed) {
+            x.emplace_back(qubitCount);
+            z.emplace_back(qubitCount);
+        }
     }
 #endif
 

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -112,8 +112,8 @@ protected:
     // By Elara (OpenAI custom GPT)
     std::vector<boost::dynamic_bitset<>> FastTranspose(const std::vector<boost::dynamic_bitset<>>& matrix)
     {
-        const size_t num_rows = matrix.size();
-        const size_t num_cols = matrix[0].size();
+        const size_t num_rows = matrix.size() - (isTransposed ? 0 : 1);
+        const size_t num_cols = matrix[0].size() + (isTransposed ? 1 : 0);
 
         std::vector<BoolVector> transposed(num_cols, BoolVector(num_rows));
 

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -326,7 +326,7 @@ public:
      * (Return value = number of such generators = log_2 of number of nonzero basis states)
      * At the bottom, generators containing Z's only in quasi-upper-triangular form.
      */
-    bitLenInt gaussian(bool s=true);
+    bitLenInt gaussian(bool s = true);
 
     bitCapInt PermCount() { return pow2(gaussian()); }
 

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -139,6 +139,12 @@ protected:
     }
 #endif
 
+    void ValidateQubitIndex(bitLenInt qubit) {
+        if (qubit >= qubitCount) {
+            throw std::domain_error("QStabilizer gate qubit indices are out-of-bounds!");
+        }
+    }
+
 public:
     QStabilizer(bitLenInt n, const bitCapInt& perm = ZERO_BCI, qrack_rand_gen_ptr rgp = nullptr,
         const complex& phaseFac = CMPLX_DEFAULT_ARG, bool doNorm = false, bool randomGlobalPhase = true,

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -104,7 +104,6 @@ protected:
         r = orig->r;
         x = orig->x;
         z = orig->z;
-        SetQubitCount(orig->qubitCount);
     }
 
 #if BOOST_AVAILABLE

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1941,6 +1941,10 @@ bool QStabilizer::ForceM(bitLenInt t, bool result, bool doForce, bool doApply)
         return false;
     }
 
+#if BOOST_AVAILABLE
+        SetTransposeState(false);
+#endif
+
     rowcopy(elemCount, m + n);
     for (bitLenInt i = m + 1U; i < n; ++i) {
         if (x[i][t]) {
@@ -1980,6 +1984,7 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
 
     SetTransposeState(false);
     toCopy->SetTransposeState(false);
+    nQubits->SetTransposeState(false);
 
     const bitLenInt oRowLength = (nQubitCount << 1U) + 1U;
     for (bitLenInt i = 0U; i < oRowLength; ++i) {
@@ -2188,6 +2193,7 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
         false, randGlobalPhase, false, -1, !!hardware_rand_generator);
 
     SetTransposeState(false);
+    nQubits->SetTransposeState(false);
 
     const bitLenInt oRowLength = (nQubitCount << 1U) + 1U;
     for (bitLenInt i = 0U; i < oRowLength; ++i) {

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1942,7 +1942,7 @@ bool QStabilizer::ForceM(bitLenInt t, bool result, bool doForce, bool doApply)
     }
 
 #if BOOST_AVAILABLE
-        SetTransposeState(false);
+    SetTransposeState(false);
 #endif
 
     rowcopy(elemCount, m + n);
@@ -1993,13 +1993,13 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
     }
 
     for (bitLenInt i = 0U; i < start; ++i) {
+        const bitLenInt ia = i + nQubitCount;
+        const bitLenInt ib = i + qubitCount;
         for (bitLenInt j = 0U; j < start; ++j) {
             nQubits->r[i] = r[i];
             nQubits->x[i][j] = x[i][j];
             nQubits->z[i][j] = z[i][j];
 
-            const bitLenInt ia = i + nQubitCount;
-            const bitLenInt ib = i + qubitCount;
             nQubits->r[ia] = r[ib];
             nQubits->x[ia][j] = x[ib][j];
             nQubits->z[ia][j] = z[ib][j];
@@ -2007,36 +2007,36 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
     }
 
     for (bitLenInt i = 0U; i < length; ++i) {
+        const bitLenInt ia = i + start;
+        const bitLenInt ib = ia + nQubitCount;
+        const bitLenInt ic = i + length;
         for (bitLenInt j = 0U; j < length; ++j) {
-            bitLenInt ia = i + start;
             const bitLenInt ja = j + start;
             nQubits->r[ia] = toCopy->r[i];
             nQubits->x[ia][ja] = toCopy->x[i][j];
             nQubits->z[ia][ja] = toCopy->z[i][j];
 
-            ia += nQubitCount;
-            const bitLenInt ib = i + length;
-            nQubits->r[ia] = r[ib];
-            nQubits->x[ia][ja] = toCopy->x[ib][j];
-            nQubits->z[ia][ja] = toCopy->z[ib][j];
+            nQubits->r[ib] = toCopy->r[ic];
+            nQubits->x[ib][ja] = toCopy->x[ic][j];
+            nQubits->z[ib][ja] = toCopy->z[ic][j];
         }
     }
 
     const bitLenInt end = start + length;
     for (bitLenInt i = 0; i < endLength; ++i) {
+        const bitLenInt ia = i + end;
+        const bitLenInt ib = i + start;
+        const bitLenInt ic = ia + nQubitCount;
+        const bitLenInt id = ib + qubitCount;
         for (bitLenInt j = 0; j < endLength; ++j) {
-            bitLenInt ia = i + end;
-            bitLenInt ib = i + start;
             const bitLenInt ja = j + end;
             nQubits->r[ia] = r[ib];
             nQubits->x[ia][ja] = x[ib][j];
             nQubits->z[ia][ja] = z[ib][j];
 
-            ia += nQubitCount;
-            ib = i + qubitCount;
-            nQubits->r[ia] = r[ib];
-            nQubits->x[ia][ja] = x[ib][j];
-            nQubits->z[ia][ja] = z[ib][j];
+            nQubits->r[ic] = r[id];
+            nQubits->x[ic][ja] = x[id][j];
+            nQubits->z[ic][ja] = z[id][j];
         }
     }
 
@@ -2085,6 +2085,7 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
 
     return start;
 }
+
 QInterfacePtr QStabilizer::Decompose(bitLenInt start, bitLenInt length)
 {
     QStabilizerPtr dest = std::make_shared<QStabilizer>(length, ZERO_BCI, rand_generator, CMPLX_DEFAULT_ARG, false,
@@ -2202,33 +2203,49 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
     }
 
     for (bitLenInt i = 0U; i < start; ++i) {
+        const bitLenInt ia = i + nQubitCount;
+        const bitLenInt ib = i + qubitCount;
         for (bitLenInt j = 0U; j < start; ++j) {
             nQubits->r[i] = r[i];
             nQubits->x[i][j] = x[i][j];
             nQubits->z[i][j] = z[i][j];
 
-            const bitLenInt ia = i + nQubitCount;
-            const bitLenInt ib = i + qubitCount;
             nQubits->r[ia] = r[ib];
             nQubits->x[ia][j] = x[ib][j];
             nQubits->z[ia][j] = z[ib][j];
         }
     }
 
-    for (bitLenInt i = 0; i < endLength; ++i) {
-        for (bitLenInt j = 0; j < endLength; ++j) {
-            bitLenInt ia = i + start;
-            bitLenInt ib = i + end;
+    for (bitLenInt i = 0U; i < length; ++i) {
+        const bitLenInt ia = i + start;
+        const bitLenInt ib = ia + qubitCount;
+        const bitLenInt ic = i + length;
+        for (bitLenInt j = 0U; j < length; ++j) {
             const bitLenInt ja = j + start;
+            dest->r[i] = r[ia];
+            dest->x[i][j] = x[ia][ja];
+            dest->z[i][j] = z[ia][ja];
+
+            dest->r[ic] = r[ib];
+            dest->x[ic][j] = x[ib][ja];
+            dest->z[ic][j] = z[ib][ja];
+        }
+    }
+
+    for (bitLenInt i = 0; i < endLength; ++i) {
+        const bitLenInt ia = i + end;
+        const bitLenInt ib = i + start;
+        const bitLenInt ic = ia + nQubitCount;
+        const bitLenInt id = ib + qubitCount;
+        for (bitLenInt j = 0; j < endLength; ++j) {
+            const bitLenInt ja = j + end;
             nQubits->r[ia] = r[ib];
             nQubits->x[ia][ja] = x[ib][j];
             nQubits->z[ia][ja] = z[ib][j];
 
-            ia += nQubitCount;
-            ib = i + qubitCount;
-            nQubits->r[ia] = r[ib];
-            nQubits->x[ia][ja] = x[ib][j];
-            nQubits->z[ia][ja] = z[ib][j];
+            nQubits->r[ic] = r[id];
+            nQubits->x[ic][ja] = x[id][j];
+            nQubits->z[ic][ja] = z[id][j];
         }
     }
 

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1969,7 +1969,6 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
     const bitLenInt length = toCopy->qubitCount;
     const bitLenInt nQubitCount = qubitCount + length;
     const bitLenInt endLength = qubitCount - start;
-    const bitLenInt secondStart = qubitCount + start;
 
 #if BOOST_AVAILABLE
     QStabilizerPtr nQubits = std::make_shared<QStabilizer>(nQubitCount, ZERO_BCI, rand_generator, CMPLX_DEFAULT_ARG,
@@ -1989,32 +1988,46 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
             nQubits->r[i] = r[i];
             nQubits->x[i][j] = x[i][j];
             nQubits->z[i][j] = z[i][j];
-            nQubits->r[i + nQubitCount] = r[i + qubitCount];
-            nQubits->x[i + nQubitCount][j] = x[i + qubitCount][j];
-            nQubits->z[i + nQubitCount][j] = z[i + qubitCount][j];
+
+            const bitLenInt ia = i + nQubitCount;
+            const bitLenInt ib = i + qubitCount;
+            nQubits->r[ia] = r[ib];
+            nQubits->x[ia][j] = x[ib][j];
+            nQubits->z[ia][j] = z[ib][j];
         }
     }
 
     for (bitLenInt i = 0U; i < length; ++i) {
         for (bitLenInt j = 0U; j < length; ++j) {
-            nQubits->r[i + start] = toCopy->r[i];
-            nQubits->x[i + start][j] = toCopy->x[i][j];
-            nQubits->z[i + start][j] = toCopy->z[i][j];
-            nQubits->r[i + nQubitCount + start] = r[i + length];
-            nQubits->x[i + nQubitCount + start][j] = toCopy->x[i + length][j];
-            nQubits->z[i + nQubitCount + start][j] = toCopy->z[i + length][j];
+            bitLenInt ia = i + start;
+            const bitLenInt ja = j + start;
+            nQubits->r[ia] = toCopy->r[i];
+            nQubits->x[ia][ja] = toCopy->x[i][j];
+            nQubits->z[ia][ja] = toCopy->z[i][j];
+
+            ia += nQubitCount;
+            const bitLenInt ib = i + length;
+            nQubits->r[ia] = r[ib];
+            nQubits->x[ia][ja] = toCopy->x[ib][j];
+            nQubits->z[ia][ja] = toCopy->z[ib][j];
         }
     }
 
     const bitLenInt end = start + length;
     for (bitLenInt i = 0; i < endLength; ++i) {
         for (bitLenInt j = 0; j < endLength; ++j) {
-            nQubits->r[i + end] = r[i + start];
-            nQubits->x[i + end][j] = x[i + start][j];
-            nQubits->z[i + end][j] = z[i + start][j];
-            nQubits->r[i + nQubitCount + end] = r[i + secondStart];
-            nQubits->x[i + nQubitCount + end][j] = x[i + secondStart][j];
-            nQubits->z[i + nQubitCount + end][j] = z[i + secondStart][j];
+            bitLenInt ia = i + end;
+            bitLenInt ib = i + start;
+            const bitLenInt ja = j + end;
+            nQubits->r[ia] = r[ib];
+            nQubits->x[ia][ja] = x[ib][j];
+            nQubits->z[ia][ja] = z[ib][j];
+
+            ia += nQubitCount;
+            ib = i + qubitCount;
+            nQubits->r[ia] = r[ib];
+            nQubits->x[ia][ja] = x[ib][j];
+            nQubits->z[ia][ja] = z[ib][j];
         }
     }
 
@@ -2022,6 +2035,7 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
 #else
     const bitLenInt rowCount = (qubitCount << 1U) + 1U;
     const bitLenInt dLen = length << 1U;
+    const bitLenInt secondStart = qubitCount + start;
 
     for (bitLenInt i = 0U; i < rowCount; ++i) {
         BoolVector& xi = x[i];

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1998,7 +1998,7 @@ bitLenInt QStabilizer::Compose(QStabilizerPtr toCopy, bitLenInt start)
             nQubits->r[i + start] = toCopy->r[i];
             nQubits->x[i + start][j] = toCopy->x[i][j];
             nQubits->z[i + start][j] = toCopy->z[i][j];
-            nQubits->r[i + nQubitCount + start] = r[i + qubitCount];
+            nQubits->r[i + nQubitCount + start] = r[i + length];
             nQubits->x[i + nQubitCount + start][j] = toCopy->x[i + length][j];
             nQubits->z[i + nQubitCount + start][j] = toCopy->z[i + length][j];
         }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -920,9 +920,6 @@ void QStabilizer::AntiCNOT(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
-    ValidateQubitIndex(c);
-    ValidateQubitIndex(t);
-
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -939,7 +936,7 @@ void QStabilizer::AntiCNOT(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (!xc[i] && (xt[i] != zc[i])) {
+        if (!xc[i] || (xt[i] != zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }
@@ -1055,7 +1052,7 @@ void QStabilizer::AntiCY(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (!xc[i] && (xt[i] != zc[i])) {
+        if (!xc[i] || (xt[i] != zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }
@@ -1184,7 +1181,7 @@ void QStabilizer::AntiCZ(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (!xc[i] && (zt[i] != zc[i])) {
+        if (!xc[i] || (zt[i] != zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1466,10 +1466,11 @@ void QStabilizer::H(bitLenInt t)
 
     const bitLenInt maxLcv = qubitCount << 1U;
     for (bitLenInt i = 0; i < maxLcv; ++i) {
-        if (xt[i] && zt[i]) {
-            uint8_t& ri = r[i];
-            ri = (ri + 2U) & 0x3U;
+        if (!xt[i] || !zt[i]) {
+            continue;
         }
+        uint8_t& ri = r[i];
+        ri = (ri + 2U) & 0x3U;
     }
 #else
     ParFor(

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -2243,7 +2243,7 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
         const bitLenInt ic = ia + nQubitCount;
         const bitLenInt id = ib + qubitCount;
         for (bitLenInt j = 0; j < endLength; ++j) {
-            const bitLenInt ja = j + end;
+            const bitLenInt ja = j + start;
             nQubits->r[ia] = r[ib];
             nQubits->x[ia][ja] = x[ib][j];
             nQubits->z[ia][ja] = z[ib][j];

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -963,7 +963,7 @@ void QStabilizer::AntiCNOT(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (xc[i] && (xt[i] == zc[i])) {
+        if (!xc[i] && (xt[i] != zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }
@@ -1135,7 +1135,7 @@ void QStabilizer::CZ(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (xc[i] && (xt[i] == zc[i])) {
+        if (xc[i] && (zt[i] == zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }
@@ -1196,7 +1196,7 @@ void QStabilizer::AntiCZ(bitLenInt c, bitLenInt t)
             continue;
         }
 
-        if (!xc[i] && (xt[i] != zc[i])) {
+        if (!xc[i] && (zt[i] != zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
         }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -922,9 +922,7 @@ void QStabilizer::CNOT(bitLenInt c, bitLenInt t)
             BoolVector& xi = x[i];
             BoolVector& zi = z[i];
 
-            if (xi[c]) {
-                xi[t] = !xi[t];
-            }
+            xi[t] = xi[t] ^ xi[c];
 
             if (zi[t]) {
                 zi[c] = !zi[c];
@@ -976,9 +974,7 @@ void QStabilizer::AntiCNOT(bitLenInt c, bitLenInt t)
             BoolVector& xi = x[i];
             BoolVector& zi = z[i];
 
-            if (xi[c]) {
-                xi[t] = !xi[t];
-            }
+            xi[t] = xi[t] ^ xi[c];
 
             if (zi[t]) {
                 zi[c] = !zi[c];
@@ -1034,10 +1030,7 @@ void QStabilizer::CY(bitLenInt c, bitLenInt t)
             BoolVector& zi = z[i];
 
             zi[t] = zi[t] ^ xi[t];
-
-            if (xi[c]) {
-                xi[t] = !xi[t];
-            }
+            xi[t] = xi[t] ^ xi[c];
 
             if (zi[t]) {
                 if (xi[c] && (xi[t] == zi[c])) {
@@ -1095,10 +1088,7 @@ void QStabilizer::AntiCY(bitLenInt c, bitLenInt t)
             BoolVector& zi = z[i];
 
             zi[t] = zi[t] ^ xi[t];
-
-            if (xi[c]) {
-                xi[t] = !xi[t];
-            }
+            xi[t] = xi[t] ^ xi[c];
 
             if (zi[t]) {
                 if (!xi[c] || (xi[t] != zi[c])) {
@@ -1167,9 +1157,7 @@ void QStabilizer::CZ(bitLenInt c, bitLenInt t)
                 }
             }
 
-            if (xi[c]) {
-                zi[t] = !zi[t];
-            }
+            zi[t] = zi[t] ^ xi[c];
         },
         { c, t });
 #endif
@@ -1230,9 +1218,7 @@ void QStabilizer::AntiCZ(bitLenInt c, bitLenInt t)
                 }
             }
 
-            if (xi[c]) {
-                zi[t] = !zi[t];
-            }
+            zi[t] = zi[t] ^ xi[c];
         },
         { c, t });
 #endif

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -60,9 +60,7 @@ QStabilizer::QStabilizer(bitLenInt n, const bitCapInt& perm, qrack_rand_gen_ptr 
 void QStabilizer::ParFor(StabilizerParallelFunc fn, std::vector<bitLenInt> qubits)
 {
     for (const bitLenInt& qubit : qubits) {
-        if (qubit >= qubitCount) {
-            throw std::domain_error("QStabilizer gate qubit indices are out-of-bounds!");
-        }
+        ValidateQubitIndex(qubit);
     }
 
     Dispatch([this, fn] {
@@ -896,6 +894,9 @@ void QStabilizer::CNOT(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -947,6 +948,9 @@ void QStabilizer::AntiCNOT(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -999,6 +1003,9 @@ void QStabilizer::CY(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1057,6 +1064,9 @@ void QStabilizer::AntiCY(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1120,6 +1130,9 @@ void QStabilizer::CZ(bitLenInt c, bitLenInt t)
         randGlobalPhase ? AmplitudeEntry(ZERO_BCI, ZERO_CMPLX) : GetQubitAmplitude(c, false);
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1181,6 +1194,9 @@ void QStabilizer::AntiCZ(bitLenInt c, bitLenInt t)
     const AmplitudeEntry ampEntry = randGlobalPhase ? AmplitudeEntry(ZERO_BCI, ZERO_CMPLX) : GetQubitAmplitude(c, true);
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1239,6 +1255,9 @@ void QStabilizer::Swap(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
     std::swap(x[c], x[t]);
     std::swap(z[c], z[t]);
@@ -1265,6 +1284,9 @@ void QStabilizer::ISwap(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1349,6 +1371,9 @@ void QStabilizer::IISwap(bitLenInt c, bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(c);
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xc = x[c];
@@ -1429,6 +1454,8 @@ void QStabilizer::H(bitLenInt t)
     const QStabilizerPtr clone = randGlobalPhase ? nullptr : std::dynamic_pointer_cast<QStabilizer>(Clone());
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xt = x[t];
@@ -1506,6 +1533,8 @@ void QStabilizer::X(bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     const bitLenInt maxLcv = qubitCount << 1U;
     if (isTransposed) {
         BoolVector& zt = z[t];
@@ -1543,6 +1572,8 @@ void QStabilizer::Y(bitLenInt t)
     }
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     const bitLenInt maxLcv = qubitCount << 1U;
     if (isTransposed) {
         BoolVector& zt = z[t];
@@ -1584,6 +1615,8 @@ void QStabilizer::Z(bitLenInt t)
         randGlobalPhase ? AmplitudeEntry(ZERO_BCI, ZERO_CMPLX) : GetQubitAmplitude(t, false);
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     const bitLenInt maxLcv = qubitCount << 1U;
     if (isTransposed) {
         BoolVector& xt = x[t];
@@ -1630,6 +1663,8 @@ void QStabilizer::S(bitLenInt t)
         randGlobalPhase ? AmplitudeEntry(ZERO_BCI, ZERO_CMPLX) : GetQubitAmplitude(t, false);
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xt = x[t];
@@ -1677,6 +1712,8 @@ void QStabilizer::IS(bitLenInt t)
         randGlobalPhase ? AmplitudeEntry(ZERO_BCI, ZERO_CMPLX) : GetQubitAmplitude(t, false);
 
 #if BOOST_AVAILABLE
+    ValidateQubitIndex(t);
+
     SetTransposeState(true);
 
     BoolVector& xt = x[t];

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1261,13 +1261,13 @@ void QStabilizer::ISwap(bitLenInt c, bitLenInt t)
 
     SetTransposeState(true);
 
+    std::swap(x[c], x[t]);
+    std::swap(z[c], z[t]);
+
     BoolVector& xc = x[c];
     BoolVector& zc = z[c];
     BoolVector& xt = x[t];
     BoolVector& zt = z[t];
-
-    std::swap(xc, xt);
-    std::swap(zc, zt);
 
     zc ^= xt;
 
@@ -1383,8 +1383,8 @@ void QStabilizer::IISwap(bitLenInt c, bitLenInt t)
         }
     }
 
-    std::swap(xc, xt);
-    std::swap(zc, zt);
+    std::swap(x[c], x[t]);
+    std::swap(z[c], z[t]);
 
 #else
     ParFor(

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -97,9 +97,12 @@ void QStabilizer::SetPermutation(const bitCapInt& perm, const complex& phaseFac)
     const bitLenInt rowCount = (qubitCount << 1U);
 
 #if BOOST_AVAILABLE
-    isTransposed = false;
-    x = std::vector<BoolVector>(rowCount + 1U, BoolVector(qubitCount));
-    z = std::vector<BoolVector>(rowCount + 1U, BoolVector(qubitCount));
+    const bitLenInt rc = (bitLenInt)x.size();
+    for (bitLenInt i = 0U; i < rc; ++i) {
+        x[i].reset();
+        z[i].reset();
+    }
+    SetTransposeState(false);
 #endif
 
     if (phaseFac != CMPLX_DEFAULT_ARG) {

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -911,7 +911,6 @@ void QStabilizer::CNOT(bitLenInt c, bitLenInt t)
         if (!zt[i]) {
             continue;
         }
-
         if (xc[i] && (xt[i] == zc[i])) {
             uint8_t& ri = r[i];
             ri = (ri + 2U) & 0x3U;
@@ -923,7 +922,9 @@ void QStabilizer::CNOT(bitLenInt c, bitLenInt t)
             BoolVector& xi = x[i];
             BoolVector& zi = z[i];
 
-            xi[t] = xi[t] ^ xi[c];
+            if (xi[c]) {
+                xi[t] = !xi[t];
+            }
 
             if (zi[t]) {
                 zi[c] = !zi[c];
@@ -1094,7 +1095,10 @@ void QStabilizer::AntiCY(bitLenInt c, bitLenInt t)
             BoolVector& zi = z[i];
 
             zi[t] = zi[t] ^ xi[t];
-            xi[t] = xi[t] ^ xi[c];
+
+            if (xi[c]) {
+                xi[t] = !xi[t];
+            }
 
             if (zi[t]) {
                 if (!xi[c] || (xi[t] != zi[c])) {
@@ -1163,7 +1167,9 @@ void QStabilizer::CZ(bitLenInt c, bitLenInt t)
                 }
             }
 
-            zi[t] = zi[t] ^ xi[c];
+            if (xi[c]) {
+                zi[t] = !zi[t];
+            }
         },
         { c, t });
 #endif
@@ -1224,7 +1230,9 @@ void QStabilizer::AntiCZ(bitLenInt c, bitLenInt t)
                 }
             }
 
-            zi[t] = zi[t] ^ xi[c];
+            if (xi[c]) {
+                zi[t] = !zi[t];
+            }
         },
         { c, t });
 #endif

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -1731,13 +1731,14 @@ bool QStabilizer::IsSeparableZ(const bitLenInt& t)
 
     // for brevity
     const bitLenInt& n = qubitCount;
-    const bitLenInt& nt2 = n << 1U;
+    const bitLenInt& nt2 = qubitCount << 1U;
 
 #if BOOST_AVAILABLE
-    SetTransposeState(true);
+    if (isTransposed) {
+        return x[t].find_next(n - 1U) >= nt2;
+    }
+#endif
 
-    return x[t].find_next(n - 1U) >= nt2;
-#else
     // loop over stabilizer generators
     for (bitLenInt p = n; p < nt2; ++p) {
         // if a Zbar does NOT commute with Z_b (the operator being measured), then outcome is random
@@ -1745,7 +1746,6 @@ bool QStabilizer::IsSeparableZ(const bitLenInt& t)
             return false;
         }
     }
-#endif
 
     return true;
 }

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -85,7 +85,9 @@ QInterfacePtr QStabilizer::Clone()
     clone->z = z;
     clone->r = r;
     clone->phaseOffset = phaseOffset;
+#if BOOST_AVAILABLE
     clone->isTransposed = isTransposed;
+#endif
 
     return clone;
 }
@@ -1847,7 +1849,9 @@ bool QStabilizer::ForceM(bitLenInt t, bool result, bool doForce, bool doApply)
             return result;
         }
 
+#if BOOST_AVAILABLE
         SetTransposeState(false);
+#endif
 
         const QStabilizerPtr clone = randGlobalPhase ? nullptr : std::dynamic_pointer_cast<QStabilizer>(Clone());
 
@@ -2262,7 +2266,9 @@ real1_f QStabilizer::ApproxCompareHelper(QStabilizerPtr toCompare, real1_f error
     toCompare->Finish();
     Finish();
 
+#if BOOST_AVAILABLE
     toCompare->SetTransposeState(false);
+#endif
 
     // log_2 of number of nonzero basis states
     const bitLenInt g = gaussian();
@@ -2905,7 +2911,9 @@ std::istream& operator>>(std::istream& is, const QStabilizerPtr s)
     size_t n;
     is >> n;
     s->SetQubitCount(n);
+#if BOOST_AVAILABLE
     s->isTransposed = false;
+#endif
 
     const size_t rows = n << 1U;
     s->r = std::vector<uint8_t>(rows + 1U);

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -2337,10 +2337,6 @@ real1_f QStabilizer::ApproxCompareHelper(QStabilizerPtr toCompare, real1_f error
     toCompare->Finish();
     Finish();
 
-#if BOOST_AVAILABLE
-    toCompare->SetTransposeState(false);
-#endif
-
     // log_2 of number of nonzero basis states
     const bitLenInt g = gaussian();
     const bitCapInt permCount = pow2(g);

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -2194,6 +2194,9 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
         false, randGlobalPhase, false, -1, !!hardware_rand_generator);
 
     SetTransposeState(false);
+    if (dest) {
+        dest->SetTransposeState(false);
+    }
     nQubits->SetTransposeState(false);
 
     const bitLenInt oRowLength = (nQubitCount << 1U) + 1U;
@@ -2216,25 +2219,27 @@ void QStabilizer::DecomposeDispose(const bitLenInt start, const bitLenInt length
         }
     }
 
-    for (bitLenInt i = 0U; i < length; ++i) {
-        const bitLenInt ia = i + start;
-        const bitLenInt ib = ia + qubitCount;
-        const bitLenInt ic = i + length;
-        for (bitLenInt j = 0U; j < length; ++j) {
-            const bitLenInt ja = j + start;
-            dest->r[i] = r[ia];
-            dest->x[i][j] = x[ia][ja];
-            dest->z[i][j] = z[ia][ja];
+    if (dest) {
+        for (bitLenInt i = 0U; i < length; ++i) {
+            const bitLenInt ia = i + start;
+            const bitLenInt ib = i + length;
+            const bitLenInt ic = ia + qubitCount;
+            for (bitLenInt j = 0U; j < length; ++j) {
+                const bitLenInt ja = j + start;
+                dest->r[i] = r[ia];
+                dest->x[i][j] = x[ia][ja];
+                dest->z[i][j] = z[ia][ja];
 
-            dest->r[ic] = r[ib];
-            dest->x[ic][j] = x[ib][ja];
-            dest->z[ic][j] = z[ib][ja];
+                dest->r[ib] = r[ic];
+                dest->x[ib][j] = x[ic][ja];
+                dest->z[ib][j] = z[ic][ja];
+            }
         }
     }
 
     for (bitLenInt i = 0; i < endLength; ++i) {
-        const bitLenInt ia = i + end;
-        const bitLenInt ib = i + start;
+        const bitLenInt ia = i + start;
+        const bitLenInt ib = i + end;
         const bitLenInt ic = ia + nQubitCount;
         const bitLenInt id = ib + qubitCount;
         for (bitLenInt j = 0; j < endLength; ++j) {

--- a/src/qunitclifford.cpp
+++ b/src/qunitclifford.cpp
@@ -535,7 +535,7 @@ bool QUnitClifford::SeparateBit(bool value, bitLenInt qubit)
     CliffordShard& shard = shards[qubit];
     const QStabilizerPtr unit = shard.unit;
 
-    if (unit->GetQubitCount() <= 1U) {
+    if (unit->GetQubitCount() == 1U) {
         unit->SetBit(0, value);
 
         return true;
@@ -812,7 +812,7 @@ bool QUnitClifford::TrySeparate(bitLenInt qubit)
 {
     CliffordShard& shard = shards[qubit];
 
-    if (shard.unit->GetQubitCount() <= 1U) {
+    if (shard.unit->GetQubitCount() == 1U) {
         return true;
     }
 

--- a/test/tests.hpp
+++ b/test/tests.hpp
@@ -153,19 +153,19 @@ public:
 
     virtual bool match(Qrack::QInterfacePtr const& qftReg) const override
     {
-        if (length == 0) {
+        if (length == 0U) {
             ((ProbPattern*)this)->length = qftReg->GetQubitCount();
         }
 
-        if (length > sizeof(mask) * 8) {
-            WARN("requested length " << length << " larger than possible bitmap " << sizeof(mask) * 8);
+        if (length > sizeof(mask) * 8U) {
+            WARN("requested length " << length << " larger than possible bitmap " << sizeof(mask) * 8U);
             return false;
         }
 
-        for (bitLenInt j = 0; j < length; j++) {
+        for (bitLenInt j = 0U; j < length; j++) {
             /* Consider anything more than a 50% probability as a '1'. */
             const bool bit = qftReg->Prob(j + start) > QRACK_TEST_EPSILON;
-            if (bit == (bi_and_1(mask >> j) == 0)) {
+            if (bit == (bi_and_1(mask >> j) == 0U)) {
                 return false;
             }
         }


### PR DESCRIPTION
This PR greatly improves stabilizer performance, by using `boost::dynamic_bitset<>` and converting between transposed forms of the stabilizer tableau, so that both unitary operations and measurement can have efficient data locality.