### PR TITLE
Highest probability method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required (VERSION 3.10)
-project (Qrack VERSION 9.25.8 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
+project (Qrack VERSION 9.26.0 DESCRIPTION "High Performance Quantum Bit Simulation" LANGUAGES CXX)
 
 # Installation commands
 include (GNUInstallDirs)

--- a/include/pinvoke_api.hpp
+++ b/include/pinvoke_api.hpp
@@ -50,6 +50,7 @@ MICROSOFT_QUANTUM_DECL void qstabilizer_out_to_file(_In_ uintq sid, _In_ char* f
 MICROSOFT_QUANTUM_DECL void qstabilizer_in_from_file(_In_ uintq sid, _In_ char* f);
 
 // pseudo-quantum
+MICROSOFT_QUANTUM_DECL void HighestProbAll(_In_ uintq sid, uintq* r);
 #if FPPOW < 6
 MICROSOFT_QUANTUM_DECL void ProbAll(_In_ uintq sid, _In_ uintq n, _In_reads_(n) uintq* q, float* p);
 #else

--- a/include/qengine_cpu.hpp
+++ b/include/qengine_cpu.hpp
@@ -219,6 +219,7 @@ public:
     real1_f ProbReg(bitLenInt start, bitLenInt length, const bitCapInt& permutation);
     real1_f ProbMask(const bitCapInt& mask, const bitCapInt& permutation);
     real1_f ProbParity(const bitCapInt& mask);
+    bitCapInt HighestProbAll();
     bitCapInt MAll();
     bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true);
     void NormalizeState(

--- a/include/qengine_cuda.hpp
+++ b/include/qengine_cuda.hpp
@@ -407,6 +407,7 @@ public:
     void SetQuantumState(const complex* inputState);
     void GetQuantumState(complex* outputState);
     void GetProbs(real1* outputProbs);
+    bitCapInt HighestProbAll();
     bitCapInt MAll();
     complex GetAmplitude(const bitCapInt& perm);
     void SetAmplitude(const bitCapInt& perm, const complex& amp);

--- a/include/qengine_opencl.hpp
+++ b/include/qengine_opencl.hpp
@@ -430,6 +430,7 @@ public:
     void SetQuantumState(const complex* inputState);
     void GetQuantumState(complex* outputState);
     void GetProbs(real1* outputProbs);
+    bitCapInt HighestProbAll();
     bitCapInt MAll();
     complex GetAmplitude(const bitCapInt& perm);
     void SetAmplitude(const bitCapInt& perm, const complex& amp);

--- a/include/qinterface.hpp
+++ b/include/qinterface.hpp
@@ -311,8 +311,6 @@ public:
     virtual void GetReducedDensityMatrix(const std::vector<bitLenInt>& qubits, complex* outputState);
 
     /** Get the pure quantum state representation
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual void GetProbs(real1* outputProbs) = 0;
 
@@ -2453,14 +2451,10 @@ public:
 
     /**
      * Direct measure of bit probability to be in |1> state
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f Prob(bitLenInt qubit) = 0;
     /**
      * Direct measure of bit probability to be in |1> state, if control bit is |1>.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f CProb(bitLenInt control, bitLenInt target)
     {
@@ -2472,8 +2466,6 @@ public:
     }
     /**
      * Direct measure of bit probability to be in |1> state, if control bit is |0>.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ACProb(bitLenInt control, bitLenInt target)
     {
@@ -2485,9 +2477,30 @@ public:
     }
 
     /**
+     * Get highest probability permutation
+     */
+    virtual bitCapInt HighestProbAll()
+    {
+        real1_f totProb = ZERO_R1_F;
+        real1_f highestProb = ZERO_R1_F;
+        bitCapInt bestPerm = ZERO_BCI;
+        for (bitCapInt p = ZERO_BCI; p < maxQPower; ++p) {
+            real1_f prob = ProbAll(p);
+            if (prob > highestProb) {
+                highestProb = prob;
+                bestPerm = p;
+            }
+            totProb += prob;
+            if (highestProb > (ONE_R1_F - totProb)) {
+                break;
+            }
+        }
+
+        return bestPerm;
+    }
+
+    /**
      * Direct measure of full permutation probability
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbAll(const bitCapInt& fullRegister)
     {
@@ -2496,8 +2509,6 @@ public:
 
     /**
      * Direct measure of register permutation probability
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbReg(bitLenInt start, bitLenInt length, const bitCapInt& permutation);
 
@@ -2507,8 +2518,6 @@ public:
      * "mask" masks the bits to check the probability of. "permutation" sets the 0 or 1 value for each bit in the mask.
      * Bits which are set in the mask can be set to 0 or 1 in the permutation, while reset bits in the mask should be 0
      * in the permutation.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbMask(const bitCapInt& mask, const bitCapInt& permutation);
 
@@ -2517,8 +2526,6 @@ public:
      *
      * "mask" masks the bits to check the probability of. The probabilities of all permutations of the masked bits, from
      * left/low to right/high are returned in the "probsArray" argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual void ProbMaskAll(const bitCapInt& mask, real1* probsArray);
 
@@ -2527,8 +2534,6 @@ public:
      *
      * The probabilities of all included permutations of bits, with bits valued from low to high as the order of the
      * "bits" array parameter argument, are returned in the "probsArray" parameter.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual void ProbBitsAll(const std::vector<bitLenInt>& bits, real1* probsArray);
 
@@ -2537,8 +2542,6 @@ public:
      *
      * The (bit string) variance of all included permutations of bits, with bits valued from low to high as the order of
      * the "bits" array parameter argument, is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceBitsAll(const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
     {
@@ -2550,8 +2553,6 @@ public:
      *
      * The (bit string, reduced density matrix) variance of all included permutations of bits, with bits valued from low
      * to high as the order of the "bits" array parameter argument, is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceBitsAllRdm(
         bool roundRz, const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
@@ -2564,8 +2565,6 @@ public:
      *
      * The (bit string) variance of all included permutations of bits, with bits valued from low to high as the order of
      * the "bits" array parameter argument,  is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VariancePauliAll(std::vector<bitLenInt> bits, std::vector<Pauli> paulis);
 
@@ -2574,8 +2573,6 @@ public:
      *
      * The (bit string) variance of all included permutations of bits, with bits valued from low to high as the order of
      * the "bits" array parameter argument,  is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceUnitaryAll(
         const std::vector<bitLenInt>& bits, const std::vector<real1_f>& basisOps, std::vector<real1_f> eigenVals = {})
@@ -2588,8 +2585,6 @@ public:
      *
      * The (bit string) variance of all included permutations of bits, with bits valued from low to high as the order of
      * the "bits" array parameter argument,  is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceUnitaryAll(const std::vector<bitLenInt>& bits,
         const std::vector<std::shared_ptr<complex>>& basisOps, std::vector<real1_f> eigenVals = {})
@@ -2602,8 +2597,6 @@ public:
      *
      * The (bit string) variance of all included permutations of bits, with bits valued from low to high as the order of
      * the "bits" array parameter argument, is returned.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceFloatsFactorized(const std::vector<bitLenInt>& bits, const std::vector<real1_f>& weights);
 
@@ -2613,8 +2606,6 @@ public:
      * The weight-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight
      * entry. If there are stabilizer ancillae, they are traced out of the reduced density matrix, giving an approximate
      * result.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceFloatsFactorizedRdm(
         bool roundRz, const std::vector<bitLenInt>& bits, const std::vector<real1_f>& weights)
@@ -2627,8 +2618,6 @@ public:
      *
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight
      * entry.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceBitsFactorized(
         const std::vector<bitLenInt>& bits, const std::vector<bitCapInt>& perms, const bitCapInt& offset = ZERO_BCI);
@@ -2639,8 +2628,6 @@ public:
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight
      * entry. If there are stabilizer ancillae, they are traced out of the reduced density matrix, giving an approximate
      * result.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f VarianceBitsFactorizedRdm(bool roundRz, const std::vector<bitLenInt>& bits,
         const std::vector<bitCapInt>& perms, const bitCapInt& offset = ZERO_BCI)
@@ -2653,8 +2640,6 @@ public:
      *
      * The permutation expectation value of all included bits is returned, with bits valued from low to high as the
      * order of the "bits" array parameter argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationBitsAll(const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
     {
@@ -2666,8 +2651,6 @@ public:
      *
      * The Pauli tensor basis expectation value of all included bits is returned, with bits valued from low to high as
      * the order of the "bits" array parameter argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationPauliAll(std::vector<bitLenInt> bits, std::vector<Pauli> paulis);
 
@@ -2676,8 +2659,6 @@ public:
      *
      * The single-qubit tensor basis (arbitrary real) expectation value of all included bits is returned, with bits
      * valued from low to high as the order of the "bits" array parameter argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationUnitaryAll(const std::vector<bitLenInt>& bits,
         const std::vector<std::shared_ptr<complex>>& basisOps, std::vector<real1_f> eigenVals = {})
@@ -2690,8 +2671,6 @@ public:
      *
      * The single-qubit (3-parameter) tensor basis (arbitrary real) expectation value of all included bits is returned,
      * with bits valued from low to high as the order of the "bits" array parameter argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationUnitaryAll(
         const std::vector<bitLenInt>& bits, const std::vector<real1_f>& basisOps, std::vector<real1_f> eigenVals = {})
@@ -2704,8 +2683,6 @@ public:
      *
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight
      * entry.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationBitsFactorized(
         const std::vector<bitLenInt>& bits, const std::vector<bitCapInt>& perms, const bitCapInt& offset = ZERO_BCI);
@@ -2716,8 +2693,6 @@ public:
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "perms" weight
      * entry. If there are stabilizer ancillae, they are traced out of the reduced density matrix, giving an approximate
      * result.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationBitsFactorizedRdm(bool roundRz, const std::vector<bitLenInt>& bits,
         const std::vector<bitCapInt>& perms, const bitCapInt& offset = ZERO_BCI)
@@ -2730,8 +2705,6 @@ public:
      *
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "weights"
      * entry.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationFloatsFactorized(
         const std::vector<bitLenInt>& bits, const std::vector<real1_f>& weights);
@@ -2742,8 +2715,6 @@ public:
      * The weighter-per-qubit expectation value of is returned, with each "bits" entry corresponding to a "weights"
      * entry. If there are stabilizer ancillae, they are traced out of the reduced density matrix, giving an approximate
      * result.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationFloatsFactorizedRdm(
         bool roundRz, const std::vector<bitLenInt>& bits, const std::vector<real1_f>& weights)
@@ -2754,14 +2725,10 @@ public:
     /**
      * Direct measure of bit probability to be in |1> state, treating all ancillary qubits as post-selected T gate
      * gadgets
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbRdm(bitLenInt qubit) { return Prob(qubit); }
     /**
      * Direct measure of full permutation probability, treating all ancillary qubits as post-selected T gate gadgets
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbAllRdm(bool roundRz, const bitCapInt& fullRegister) { return ProbAll(fullRegister); }
     /**
@@ -2770,8 +2737,6 @@ public:
      * "mask" masks the bits to check the probability of. "permutation" sets the 0 or 1 value for each bit in the mask.
      * Bits which are set in the mask can be set to 0 or 1 in the permutation, while reset bits in the mask should be 0
      * in the permutation.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ProbMaskRdm(bool roundRz, const bitCapInt& mask, const bitCapInt& permutation)
     {
@@ -2782,8 +2747,6 @@ public:
      *
      * The permutation expectation value of all included bits is returned, with bits valued from low to high as the
      * order of the "bits" array parameter argument.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual real1_f ExpectationBitsAllRdm(
         bool roundRz, const std::vector<bitLenInt>& bits, const bitCapInt& offset = ZERO_BCI)
@@ -2802,8 +2765,6 @@ public:
      * the state of this QInterface. (The idea is to efficiently simulate a potentially statistically random sample of
      * multiple re-preparations of the state right before measurement, and to collect random measurement resutls,
      * without forcing the user to re-prepare or "clone" the state.)
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual std::map<bitCapInt, int> MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots);
 
@@ -2811,8 +2772,6 @@ public:
      * Statistical measure of masked permutation probability (returned as array)
      *
      * Same `Qrack::MultiShotMeasureMask()`, except the shots are returned as an array.
-     *
-     * \warning PSEUDO-QUANTUM
      */
     virtual void MultiShotMeasureMask(
         const std::vector<bitCapInt>& qPowers, unsigned shots, unsigned long long* shotsArray);

--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -323,6 +323,7 @@ public:
         bi_div_mod(perm, pageMaxQPower(), &p, &a);
         return qPages[(bitCapIntOcl)p]->ProbAll(a);
     }
+    bitCapInt HighestProbAll();
 
     void SetPermutation(const bitCapInt& perm, const complex& phaseFac = CMPLX_DEFAULT_ARG);
 

--- a/include/qstabilizer.hpp
+++ b/include/qstabilizer.hpp
@@ -421,6 +421,9 @@ public:
     /// Measure qubit t
     bool ForceM(bitLenInt t, bool result, bool doForce = true, bool doApply = true);
 
+    /// Get the highest-probability basis dimension in the Hilbert space
+    bitCapInt HighestProbAll();
+
     /// Convert the state to ket notation
     void GetQuantumState(complex* stateVec);
 

--- a/include/qstabilizerhybrid.hpp
+++ b/include/qstabilizerhybrid.hpp
@@ -470,6 +470,19 @@ public:
         return prob;
     }
 
+    bitCapInt HighestProbAll()
+    {
+        if (engine) {
+            return engine->HighestProbAll();
+        }
+
+        if (!ancillaCount && !deadAncillaCount && !IsLogicalProbBuffered()) {
+            return stabilizer->HighestProbAll();
+        }
+
+        return QInterface::HighestProbAll();
+    }
+
     /**
      * Switches between CPU and GPU used modes. (This will not incur a performance penalty, if the chosen mode matches
      * the current mode.) Mode switching happens automatically when qubit counts change, but Compose() and Decompose()

--- a/include/qtensornetwork.hpp
+++ b/include/qtensornetwork.hpp
@@ -171,6 +171,13 @@ public:
         return toRet;
     }
 
+    bitCapInt HighestProbAll()
+    {
+        bitCapInt toRet;
+        RunAsAmplitudes([&](QInterfacePtr ls) { toRet = ls->HighestProbAll(); });
+        return toRet;
+    }
+
     void SetDevice(int64_t dID) { devID = dID; }
     void SetDeviceList(std::vector<int64_t> dIDs) { deviceIDs = dIDs; }
     int64_t GetDevice() { return devID; }

--- a/include/qunit.hpp
+++ b/include/qunit.hpp
@@ -353,6 +353,7 @@ public:
     using QInterface::ForceMReg;
     virtual bitCapInt ForceMReg(
         bitLenInt start, bitLenInt length, const bitCapInt& result, bool doForce = true, bool doApply = true);
+    virtual bitCapInt HighestProbAll();
     virtual bitCapInt MAll();
     virtual std::map<bitCapInt, int> MultiShotMeasureMask(const std::vector<bitCapInt>& qPowers, unsigned shots);
     virtual void MultiShotMeasureMask(

--- a/scripts/maxcut_approx.py
+++ b/scripts/maxcut_approx.py
@@ -314,7 +314,7 @@ if __name__ == "__main__":
     # G.add_edge(0, 5, weight=1.29)
 
     # NP-complete spin glass
-    G = generate_spin_glass_graph(seed=42)
+    G = generate_spin_glass_graph(n_nodes=64, seed=42)
 
     cut_value, bitstring, cut_edges = maxcut_tfim(G)
 

--- a/scripts/maxcut_np-complete.py
+++ b/scripts/maxcut_np-complete.py
@@ -1,0 +1,47 @@
+# MAXCUT
+# Produced by Dan Strano, Elara (the OpenAI custom GPT), and Gemini (Google Search AI)
+
+# We reduce transverse field Ising model for globally uniform J and h parameters from a 2^n-dimensional problem to an (n+1)-dimensional approximation that suffers from no Trotter error. Upon noticing most time steps for Quantinuum's parameters had roughly a quarter to a third (or thereabouts) of their marginal probability in |0> state, it became obvious that transition to and from |0> state should dominate the mechanics. Further, the first transition tends to be to or from any state with Hamming weight of 1 (in other words, 1 bit set to 1 and the rest reset 0, or n bits set for Hamming weight of n). Further, on a torus, probability of all states with Hamming weight of 1 tends to be exactly symmetric. Assuming approximate symmetry in every respective Hamming weight, the requirement for the overall probability to converge to 1.0 or 100% in the limit of an infinite-dimensional Hilbert space suggests that Hamming weight marginal probability could be distributed like a geometric series. A small correction to exact symmetry should be made to favor closeness of "like" bits to "like" bits (that is, geometric closeness on the torus of "1" bits to "1" bits and "0" bits to "0" bits), but this does not affect average global magnetization. Adding an oscillation component with angular frequency proportional to J, we find excellent agreement with Trotterization approaching the limit of infinitesimal time step, for R^2 (coefficient of determination) of normalized marginal probability distribution of ideal Trotterized simulation as described by the (n+1)-dimensional approximate model, as well as for R^2 and RMSE (root-mean-square error) of global magnetization curve values.
+
+# After tackling the case where parameters are uniform and independent of time, we generalize the model by averaging per-qubit behavior as if the static case and per-time-step behavior as finite difference. This provides the basis of a novel physics-inspired (adiabatic TFIM) MAXCUT approximate solver that often gives optimal or exact answers on a wide selection of graph types.
+
+from PyQrackIsing import maxcut_tfim
+import networkx as nx
+import numpy as np
+
+
+# NP-complete spin glass
+def generate_spin_glass_graph(n_nodes=16, degree=3, seed=None):
+    if not (seed is None):
+        np.random.seed(seed)
+    G = nx.random_regular_graph(d=degree, n=n_nodes, seed=seed)
+    for u, v in G.edges():
+        G[u][v]['weight'] = np.random.choice([-1, 1])  # spin glass couplings
+    return G
+
+
+def flip_spin(spins, i):
+    new_spins = spins.copy()
+    new_spins[i] *= -1
+    return new_spins
+
+
+if __name__ == "__main__":
+    # NP-complete spin glass
+    G = generate_spin_glass_graph(n_nodes=16, seed=42)
+
+    cut_value, bitstring, cut_edges = maxcut_tfim(G, quality=11)
+
+    print((cut_value, bitstring, cut_edges))
+
+    # Convert bitstring to spins
+    spins = {i: 1 if bitstring[i] == '1' else -1 for i in range(len(bitstring))}
+
+    # Reconstruct Ising energy (note: MAXCUT flips sign!)
+    E_claim = -sum(G[u][v].get("weight", 1) * spins[u] * spins[v] for u, v in G.edges())
+
+    for i in range(10):  # Try 10 random single spin flips
+        idx = np.random.randint(0, len(spins))
+        perturbed = flip_spin(spins, idx)
+        E_perturbed = -sum(G[u][v].get("weight", 1) * perturbed[u] * perturbed[v] for u, v in G.edges())
+        assert E_claim <= E_perturbed  # Should not find a better energy)

--- a/src/pinvoke_api.cpp
+++ b/src/pinvoke_api.cpp
@@ -2603,6 +2603,28 @@ MICROSOFT_QUANTUM_DECL void CLXNOR(_In_ uintq sid, _In_ bool ci, _In_ uintq qi, 
     }
 }
 
+/**
+ * (External API) Get the permutation with the highest probability
+ */
+MICROSOFT_QUANTUM_DECL void HighestProbAll(_In_ uintq sid, uintq* r)
+{
+    SIMULATOR_LOCK_GUARD_VOID(sid)
+    try {
+        bitCapInt _r = simulator->HighestProbAll();
+        constexpr bitLenInt bitsPerWord = (bitLenInt)(sizeof(bitCapIntOcl) << 3U);
+        const bitLenInt maxWords = (simulator->GetQubitCount() + bitsPerWord - 1) / bitsPerWord;
+        const bitCapInt mask = pow2(bitsPerWord) - 1U;
+        for (bitLenInt w = 0U; w < maxWords; ++w) {
+            r[w] = (bitCapIntOcl)(mask & _r);
+            _r = _r >> bitsPerWord;
+        }
+    } catch (const std::exception& ex) {
+        simulatorErrors[sid] = 1;
+        std::cout << ex.what() << std::endl;
+    }
+}
+
+
 double _Prob(_In_ uintq sid, _In_ uintq q, bool isRdm)
 {
     SIMULATOR_LOCK_GUARD_DOUBLE(sid)

--- a/src/qengine/cuda.cu
+++ b/src/qengine/cuda.cu
@@ -2900,10 +2900,45 @@ void QEngineCUDA::SetQuantumState(const complex* inputState)
     UpdateRunningNorm();
 }
 
+bitCapInt QEngineCUDA::HighestProbAll()
+{
+    clFinish(false);
+
+    if (!stateBuffer) {
+        return ZERO_BCI;
+    }
+
+    LockSync(CL_MAP_READ);
+
+    const unsigned numCores = GetConcurrencyLevel();
+    std::unique_ptr<real1[]> highestProbs(new real1[numCores]());
+    std::unique_ptr<bitCapIntOcl[]> bestPerms(new bitCapIntOcl[numCores]());
+    par_for(0U, maxQPowerOcl, [&](const bitCapIntOcl& lcv, const unsigned& cpu) {
+        real1_f prob = norm(stateVec.get()[lcv]);
+        if (prob > highestProbs[cpu]) {
+            highestProbs[cpu] = prob;
+            bestPerms[cpu] = lcv;
+        }
+    });
+
+    real1 highestProb = ZERO_R1;
+    bitCapIntOcl bestPerm = 0U;
+    for (unsigned i = 0U; i < numCores; ++i) {
+        if (highestProbs[i] > highestProb) {
+            highestProb = highestProbs[i];
+            bestPerm = bestPerms[i];
+        }
+    }
+
+    UnlockSync();
+
+    return bestPerm;
+}
+
 bitCapInt QEngineCUDA::MAll()
 {
     if (!stateBuffer) {
-        return 0U;
+        return ZERO_BCI;
     }
 
     const real1_f rnd = Rand();

--- a/src/qpager.cpp
+++ b/src/qpager.cpp
@@ -915,6 +915,23 @@ void QPager::GetProbs(real1* outputProbs)
 #endif
 }
 
+bitCapInt QPager::HighestProbAll()
+{
+    const bitCapIntOcl pagePower = (bitCapIntOcl)pageMaxQPower();
+    real1_f highestProb = ZERO_R1_F;
+    bitCapInt bestPerm = ZERO_BCI;
+    for (bitCapIntOcl i = 0U; i < qPages.size(); ++i) {
+        bitCapInt highestPageProb = qPages[i]->HighestProbAll();
+        real1_f prob = qPages[i]->ProbAll(highestPageProb);
+        if (prob > highestProb) {
+            highestProb = prob;
+            bestPerm = highestPageProb + (i * pagePower);
+        }
+    }
+
+    return bestPerm;
+}
+
 void QPager::SetPermutation(const bitCapInt& perm, const complex& phaseFac)
 {
     const bitCapIntOcl pagePower = (bitCapIntOcl)pageMaxQPower();

--- a/src/qstabilizer.cpp
+++ b/src/qstabilizer.cpp
@@ -475,8 +475,18 @@ real1_f QStabilizer::getVariance(const real1_f& mean, const real1_f& nrm, const 
     return diff * diff * norm(entry.amplitude);
 }
 
-#define C_SQRT1_2 complex(M_SQRT1_2, ZERO_R1)
-#define C_I_SQRT1_2 complex(ZERO_R1, M_SQRT1_2)
+/// Get all probabilities corresponding to ket notation
+bitCapInt QStabilizer::HighestProbAll()
+{
+    Finish();
+
+    // log_2 of number of nonzero basis states
+    const bitLenInt g = gaussian();
+    const real1_f nrm = sqrt(ONE_R1_F / (real1_f)bi_to_double(pow2(g)));
+    const AmplitudeEntry entry = getBasisAmp(nrm);
+
+    return entry.permutation;
+}
 
 /// Convert the state to ket notation (warning: could be huge!)
 void QStabilizer::GetQuantumState(complex* stateVec)

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1489,9 +1489,16 @@ bitCapInt QUnit::HighestProbAll()
     bitCapInt toRet = ZERO_BCI;
     for (bitLenInt i = 0U; i < shards.size(); ++i) {
         const QEngineShard& shard = shards[i];
-        const bitCapInt& p = perms[shard.unit];
-        if (bi_compare_1(p >> shard.mapped) == 0) {
-            toRet = toRet | pow2(i);
+        if (!shard.unit) {
+            real1_f prob = norm(shards[i].amp1);
+            if (prob >= 0.5) {
+                toRet = toRet | pow2(i);
+            }
+        } else {
+            const bitCapInt& p = perms[shard.unit];
+            if (bi_compare_1(p >> shard.mapped) == 0) {
+                toRet = toRet | pow2(i);
+            }
         }
     }
 

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1472,6 +1472,32 @@ bitCapInt QUnit::ForceMReg(bitLenInt start, bitLenInt length, const bitCapInt& r
     return QInterface::ForceMReg(start, length, result, doForce, doApply);
 }
 
+bitCapInt QUnit::HighestProbAll()
+{
+    ToPermBasisProb();
+
+    std::vector<QInterfacePtr> units;
+    std::map<QInterfacePtr, bitCapInt> perms;
+    for (const QEngineShard& shard : shards) {
+        const QInterfacePtr& toFind = shard.unit;
+        if (toFind && (find(units.begin(), units.end(), toFind) == units.end())) {
+            units.push_back(toFind);
+            perms[toFind] = toFind->HighestProbAll();
+        }
+    }
+
+    bitCapInt toRet = ZERO_BCI;
+    for (bitLenInt i = 0U; i < shards.size(); ++i) {
+        const QEngineShard& shard = shards[i];
+        const bitCapInt& p = perms[shard.unit];
+        if (bi_compare_1(p >> shard.mapped) == 0) {
+            toRet = toRet | pow2(i);
+        }
+    }
+
+    return toRet;
+}
+
 bitCapInt QUnit::MAll()
 {
     for (bitLenInt i = 0U; i < qubitCount; ++i) {

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1489,14 +1489,14 @@ bitCapInt QUnit::HighestProbAll()
     bitCapInt toRet = ZERO_BCI;
     for (bitLenInt i = 0U; i < shards.size(); ++i) {
         const QEngineShard& shard = shards[i];
-        if (!shard.unit) {
-            real1_f prob = norm(shards[i].amp1);
+        const QInterfacePtr& unit = shard.unit;
+        if (!unit) {
+            real1_f prob = norm(shard.amp1);
             if (prob >= 0.5) {
                 toRet = toRet | pow2(i);
             }
         } else {
-            const bitCapInt& p = perms[shard.unit];
-            if (bi_compare_1(p >> shard.mapped) == 0) {
+            if (bi_compare_1(perms[unit] >> shard.mapped) == 0) {
                 toRet = toRet | pow2(i);
             }
         }

--- a/src/qunit.cpp
+++ b/src/qunit.cpp
@@ -1496,7 +1496,7 @@ bitCapInt QUnit::HighestProbAll()
                 toRet = toRet | pow2(i);
             }
         } else {
-            if (bi_compare_1(perms[unit] >> shard.mapped) == 0) {
+            if (bi_compare_1((perms[unit] >> shard.mapped) & 1) == 0) {
                 toRet = toRet | pow2(i);
             }
         }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -318,6 +318,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_setconcurrency")
     qftReg->SetConcurrency(1);
 }
 
+TEST_CASE_METHOD(QInterfaceTestFixture, "test_highestproball")
+{
+    qftReg->SetPermutation(42U);
+    REQUIRE((bitCapIntOcl)qftReg->HighestProbAll() == 42U);
+}
+
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
 {
     qftReg =

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -320,8 +320,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_setconcurrency")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_highestproball")
 {
-    qftReg->SetPermutation(42U);
-    REQUIRE((bitCapIntOcl)qftReg->HighestProbAll() == 42U);
+    qftReg->SetPermutation(42);
+    REQUIRE((bitCapIntOcl)qftReg->HighestProbAll() == 42);
+
+    qftReg->RX(0.1, 1);
+    qftReg->CNOT(1, 6);
+    REQUIRE((bitCapIntOcl)qftReg->HighestProbAll() == 106);
 }
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")


### PR DESCRIPTION
This PR adds a method to (efficiently) retrieve the bit string in the simulator Hilbert space with the overall highest probability.