### PR TITLE
Fixes #1036

### DIFF
--- a/include/qpager.hpp
+++ b/include/qpager.hpp
@@ -428,7 +428,6 @@ public:
 
     real1_f Prob(bitLenInt qubitIndex);
     real1_f ProbMask(const bitCapInt& mask, const bitCapInt& permutation);
-    // TODO: QPager not yet used in Q#, but this would need a real implementation:
     real1_f ProbParity(const bitCapInt& mask)
     {
         if (bi_compare_0(mask) == 0) {
@@ -441,7 +440,7 @@ public:
     bool ForceMParity(const bitCapInt& mask, bool result, bool doForce = true)
     {
         if (bi_compare_0(mask) == 0) {
-            return ZERO_R1_F;
+            return false;
         }
 
         CombineEngines();

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -3459,7 +3459,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_expectationbitsall")
     REQUIRE_FLOAT(qftReg->ExpectationBitsAll(bits), 127 + (ONE_R1_F / 2))
 }
 
-#if 0
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_probparity")
 {
     if (testEngineType == QINTERFACE_TENSOR_NETWORK) {
@@ -3495,6 +3494,9 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mparity")
     }
 
     qftReg->SetPermutation(0x0);
+    REQUIRE(!(QPARITY(qftReg)->ForceMParity(0x0, true, true)));
+
+    qftReg->SetPermutation(0x0);
     qftReg->H(0);
     REQUIRE(QPARITY(qftReg)->ForceMParity(0x1, true, true));
     REQUIRE(QPARITY(qftReg)->MParity(0x1));
@@ -3510,7 +3512,6 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_mparity")
     REQUIRE(!(QPARITY(qftReg)->ForceMParity(0x3, false, true)));
     REQUIRE(!(QPARITY(qftReg)->MParity(0x3)));
 }
-#endif
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_uniformparityrz")
 {

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -349,6 +349,11 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_highestproball")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
 {
+    if (testEngineType == QINTERFACE_TENSOR_NETWORK) {
+        // Not yet supported.
+        return;
+    }
+
     qftReg =
         CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType, testSubSubSubEngineType }, 1U,
             ZERO_BCI, rng, CMPLX_DEFAULT_ARG, false, false);


### PR DESCRIPTION
Skip `test_global_phase` for `QTensorNetwork`: this is a long-known limitation of the method that is not expected to pass the assertion. This fixes #1036.