### PR TITLE
Skip test_global_phase for QTensorNetwork (#1036)

### DIFF
--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -349,6 +349,12 @@ TEST_CASE_METHOD(QInterfaceTestFixture, "test_highestproball")
 
 TEST_CASE_METHOD(QInterfaceTestFixture, "test_global_phase")
 {
+    if (testEngineType == QINTERFACE_TENSOR_NETWORK) {
+        // Global phase is not tracked: it is physically unobservable, and preserving it is a
+        // known limitation of the underlying simulation method rather than a defect. (See #1036.)
+        return;
+    }
+
     qftReg =
         CreateQuantumInterface({ testEngineType, testSubEngineType, testSubSubEngineType, testSubSubSubEngineType }, 1U,
             ZERO_BCI, rng, CMPLX_DEFAULT_ARG, false, false);


### PR DESCRIPTION
Closes #1036.

Per your call on the issue: `QTensorNetwork` does not track global phase, this is a known limitation of the underlying method rather than a defect (global phase is physically unobservable), so `test_global_phase` should skip this layer rather than assert against it.

The guard matches the one already used for `QINTERFACE_TENSOR_NETWORK` elsewhere in the file (e.g. `test_probparity`):

```cpp
if (testEngineType == QINTERFACE_TENSOR_NETWORK) {
    // ... known limitation ...
    return;
}
```

### Verified

- `./unittest --layer-qtensornetwork --proc-cpu test_global_phase` now passes (skips cleanly, `assertions: - none -`).
- The layer's overall failure count drops by exactly one (40 → 39) — this removes `test_global_phase` and nothing else.
- Default layers unaffected: `./unittest --proc-cpu` → 212 cases, 9606 assertions, all passing.
